### PR TITLE
Feature-cleanPlan_completeCheck

### DIFF
--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,0 +1,19 @@
+const jwt = require("jsonwebtoken");
+const { User } = require("../models");
+
+module.exports = (req, res, next) => {
+  try {
+    const token = req.headers["x-access-token"];
+    if (!token) {
+      throw new Error("로그인 후 사용해 주세요.");
+    }
+
+    const { userId } = jwt.verify(token, process.env.secretKey);
+    User.findOne({ where: { authId: userId } }).then((user) => {
+      res.locals.user = user;
+      next();
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/models/cleanPlan.js
+++ b/models/cleanPlan.js
@@ -28,7 +28,7 @@ module.exports = (sequelize, DataTypes) => {
       title: DataTypes.STRING,
       notification: DataTypes.STRING,
       detail: DataTypes.STRING,
-      isCompleted: DataTypes.BOOLEAN,
+      isCompleted: { type: DataTypes.BOOLEAN, defaultValue: false },
     },
     {
       sequelize,

--- a/models/cleanPlan.js
+++ b/models/cleanPlan.js
@@ -1,7 +1,7 @@
 "use strict";
 const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
-  class User extends Model {
+  class CleanPlan extends Model {
     /**
      * Helper method for defining associations.
      * This method is not a part of Sequelize lifecycle.
@@ -9,29 +9,31 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      this.hasMany(models.CleanPlan, {
+      this.belongsTo(models.User, {
         foreignKey: "authId",
-        sourceKey: "authId",
+        targetKey: "authId",
+        onDelete: "cascade",
       });
     }
   }
-  User.init(
+  CleanPlan.init(
     {
-      authId: {
+      cleanPlanId: {
         primaryKey: true,
         type: DataTypes.INTEGER,
         autoIncrement: true,
       },
-      snsId: DataTypes.INTEGER,
-      email: DataTypes.STRING,
-      provider: DataTypes.STRING,
-      nickname: DataTypes.STRING,
-      userImageURL: DataTypes.STRING,
+      date: DataTypes.STRING,
+      category: DataTypes.STRING,
+      title: DataTypes.STRING,
+      notification: DataTypes.STRING,
+      detail: DataTypes.STRING,
+      isCompleted: DataTypes.BOOLEAN,
     },
     {
       sequelize,
-      modelName: "User",
+      modelName: "CleanPlan",
     }
   );
-  return User;
+  return CleanPlan;
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
+    "dotenv": "^16.0.3",
     "ejs": "~2.6.1",
     "express": "~4.16.1",
     "express-session": "^1.17.3",

--- a/routes/cleanPlan.js
+++ b/routes/cleanPlan.js
@@ -1,0 +1,106 @@
+const express = require("express");
+const { CleanPlan } = require("../models");
+const router = express.Router();
+const authMiddleware = require("../middlewares/authMiddleware");
+
+// 일정 작성 [POST] /cleanPlan
+router.post("/", async (req, res, next) => {
+  try {
+    // 사용자 인증 미들웨어 authMiddleware 추가하고 authId는 res.locals.user로 바꾸기
+    const { authId } = req.body;
+    const { date, category, title, notification, detail } = req.body;
+
+    const data = await CleanPlan.create({
+      authId,
+      date,
+      category,
+      title,
+      notification,
+      detail,
+    });
+
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// 일정 수정 [PUT] /cleanPlan/:cleanPlanId
+router.put("/:cleanPlanId", async (req, res, next) => {
+  try {
+    // 사용자 인증 미들웨어 authMiddleware 추가하고 authId는 res.locals.user로 바꾸기
+    const { authId } = req.body;
+    const { date, category, title, notification, detail } = req.body;
+    const { cleanPlanId } = req.params;
+
+    const cleanPlanData = await CleanPlan.findOne({ where: { cleanPlanId } });
+    if (!cleanPlanData) {
+      throw new Error("일정이 존재하지 않습니다.");
+    }
+    if (cleanPlanData.authId !== authId) {
+      throw new Error("본인 일정만 수정 가능합니다.");
+    }
+
+    const data = await CleanPlan.update(
+      {
+        authId,
+        date,
+        category,
+        title,
+        notification,
+        detail,
+      },
+      { where: { cleanPlanId } }
+    );
+
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// 일정 삭제 [DELETE] /cleanPlan/:cleanPlanId
+router.delete("/:cleanPlanId", async (req, res, next) => {
+  try {
+    // 사용자 인증 미들웨어 authMiddleware 추가하고 authId는 res.locals.user로 바꾸기
+    const { authId } = req.body;
+    const { cleanPlanId } = req.params;
+
+    const cleanPlanData = await CleanPlan.findOne({ where: { cleanPlanId } });
+    if (!cleanPlanData) {
+      throw new Error("일정이 존재하지 않습니다.");
+    }
+    if (cleanPlanData.authId !== authId) {
+      throw new Error("본인 일정만 삭제 가능합니다.");
+    }
+
+    await CleanPlan.destroy({ where: { cleanPlanId } });
+
+    res.status(200).json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// 청소 상세 조회 [GET] /cleanPlan/:cleanPlanId
+router.get("/:cleanPlanId", async (req, res, next) => {
+  try {
+    // 사용자 인증 미들웨어 authMiddleware 추가하고 authId는 res.locals.user로 바꾸기
+    const { authId } = req.body;
+    const { cleanPlanId } = req.params;
+
+    const cleanPlanData = await CleanPlan.findOne({ where: { cleanPlanId } });
+    if (!cleanPlanData) {
+      throw new Error("일정이 존재하지 않습니다.");
+    }
+    if (cleanPlanData.authId !== authId) {
+      throw new Error("본인 일정만 조회 가능합니다.");
+    }
+
+    res.status(200).json({ success: true, data: cleanPlanData });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/routes/cleanPlan.js
+++ b/routes/cleanPlan.js
@@ -103,4 +103,32 @@ router.get("/:cleanPlanId", async (req, res, next) => {
   }
 });
 
+// 일정 완료/취소 [PUT] /cleanPlan/:cleanPlanId/completed
+router.put("/:cleanPlanId/completed", async (req, res, next) => {
+  try {
+    // 사용자 인증 미들웨어 authMiddleware 추가하고 authId는 res.locals.user로 바꾸기
+    const { authId } = req.body;
+    const { cleanPlanId } = req.params;
+
+    const cleanPlanData = await CleanPlan.findOne({ where: { cleanPlanId } });
+    if (!cleanPlanData) {
+      throw new Error("일정이 존재하지 않습니다.");
+    }
+    if (cleanPlanData.authId !== authId) {
+      throw new Error("본인 일정만 완료 및 취소 가능합니다.");
+    }
+
+    await CleanPlan.update(
+      { isCompleted: cleanPlanData.isCompleted ? false : true },
+      { where: { cleanPlanId } }
+    );
+
+    res
+      .status(200)
+      .json({ success: true, isCompleted: !cleanPlanData.isCompleted });
+  } catch (error) {
+    next(error);
+  }
+});
+
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ var router = express.Router();
 
 const naverRouter = require("./naver");
 const kakaoRouter = require("./kakao");
+const cleanPlan = require("./cleanPlan");
 
 router.get("/", (req, res) => {
   res.status(200).json({ massage: "서버 정상" });
@@ -10,5 +11,6 @@ router.get("/", (req, res) => {
 
 router.use("/kakao", kakaoRouter);
 router.use("/naver", naverRouter);
+router.use("/cleanPlan", cleanPlan);
 
 module.exports = router;


### PR DESCRIPTION
일정 crud랑 일정 완료/취소 처리 구현했습니다. 

사용자 인증 미들웨어는 적용 안 해놔서 바로 로그인 없이 테스트 가능해요


[.env]

PORT=

MYSQL_USERNAME=
MYSQL_PASSWORD=
MYSQL_DATABASE=
MYSQL_HOST=127.0.0.1

KAKAO_ID=(kakao, naver 부분은 일단 아무거나 적고 일정 crud 테스트 했어요)
KAKAO_CALLBACK_URL=

NAVER_ID=
NAVER_SECRET=
NAVER_CALLBACK_URL=

secretKey=(jwt 토큰 시크릿키)